### PR TITLE
Add missing deps

### DIFF
--- a/jenkins/plugins.txt
+++ b/jenkins/plugins.txt
@@ -12,9 +12,11 @@ github:latest
 copyartifact:latest
 plain-credentials:latest
 credentials:latest
+workflow-step-api:latest
 credentials-binding:latest
 ssh-agent:latest
 discard-old-build:latest
+config-file-provider:latest
 managed-scripts:latest
 envinject:latest
 instant-messaging:latest


### PR DESCRIPTION
Turns out some of the plugins I was missing where throwing dependency errors in the log.

Looks like I cleaned up a bit to fast when I grabbed this from elsewhere.