### PR TITLE
[TASK] Add build-token-root plugin

### DIFF
--- a/jenkins/plugins.txt
+++ b/jenkins/plugins.txt
@@ -1,4 +1,5 @@
 authentication-tokens:latest
+build-token-root:latest
 durable-task:latest
 token-macro:latest
 docker-plugin:latest


### PR DESCRIPTION
Allow remote systems to trigger builds. Identified by token. Even
though GeneralRead and RunScripts permissions are missing for anonymous
users.